### PR TITLE
Update Troco issue 4-9.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -12,35 +12,12 @@ class Troco {
 
     public Troco(int valor) {
         papeisMoeda = new PapelMoeda[6];
-        int count = 0;
-        while (valor % 100 != 0) {
-            count++;
-            papeisMoeda[5] = new PapelMoeda(100, count);
-        }
-        count = 0;
-        while (valor % 50 != 0) {
-            count++;
-        }
-        papeisMoeda[4] = new PapelMoeda(50, count);
-        count = 0;
-        while (valor % 20 != 0) {
-            count++;
-        }
-        papeisMoeda[3] = new PapelMoeda(20, count);
-        count = 0;
-        while (valor % 10 != 0) {
-            count++;
-        }
-        papeisMoeda[2] = new PapelMoeda(10, count);
-        count = 0;
-        while (valor % 5 != 0) {
-            count++;
-            papeisMoeda[1] = new PapelMoeda(5, count);
-        }
-        count = 0;
-        while (valor % 2 != 0) {
-            count++;
-            papeisMoeda[0] = new PapelMoeda(2, count);
+        int[] valoresMoedas = {100, 50, 20, 10, 5, 2};
+
+        for (int i = 0; i < valoresMoedas.length; i++) {
+            int count = valor / valoresMoedas[i];
+            valor %= valoresMoedas[i];
+            papeisMoeda[i] = new PapelMoeda(valoresMoedas[i], count);
         }
     }
 


### PR DESCRIPTION
Os loops `while` foram removidos devido a falhas que resultavam em loops infinitos, prejudicando o funcionamento adequado do código. A nova função foi desenvolvida para distribuir o valor utilizando a menor quantidade possível de notas.
``` 
int[] valoresMoedas = {100, 50, 20, 10, 5, 2};

        for (int i = 0; i < valoresMoedas.length; i++) {
            int count = valor / valoresMoedas[i];
            valor %= valoresMoedas[i];
            papeisMoeda[i] = new PapelMoeda(valoresMoedas[i], count);
        } 
```